### PR TITLE
update deployments to use GH docker images

### DIFF
--- a/order-processor-deployment.yaml
+++ b/order-processor-deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: order-processor
-        image: gpickers/order-processor
+        image: ghcr.io/georgep1ckers/tracey-reloaded-order-processor:latest
         ports:
         - containerPort: 8080

--- a/stock-controller-deployment.yaml
+++ b/stock-controller-deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: stock-controller
-        image: gpickers/stock-controller
+        image: ghcr.io/georgep1ckers/tracey-reloaded-stock-controller:latest
         ports:
         - containerPort: 8081

--- a/warehouse-interface-deployment.yaml
+++ b/warehouse-interface-deployment.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: warehouse-interface
-        image: gpickers/warehouse-interface
+        image: ghcr.io/georgep1ckers/tracey-reloaded-warehouse-interface:latest


### PR DESCRIPTION
Modify the K8s deployment files to use the latest image generated in the GH repo