### PR TITLE
move wait out of trace loop

### DIFF
--- a/warehouse-interface/warehouse-interface.py
+++ b/warehouse-interface/warehouse-interface.py
@@ -290,5 +290,5 @@ if __name__ == "__main__":
             else:
                 custom_logger("No more orders to pick up",level='info')
             
-            # Wait for 10 seconds before the next iteration
-            time.sleep(10)
+        # Wait for 10 seconds before the next iteration
+        time.sleep(10)


### PR DESCRIPTION
moving the wait logic out of the loop which has the parent trace to better reflect the logic we wish to see in Coralogix. 